### PR TITLE
Elasticsearch install instructions

### DIFF
--- a/admin-manual/installation/linux.rst
+++ b/admin-manual/installation/linux.rst
@@ -60,8 +60,7 @@ probably the biggest change introduced in AtoM |version| and we are pleased
 with the results.
 
 Ubuntu doesn't provide a package but you can download it directly from the
-`Elasticsearch site <http://www.elasticsearch.org/download/>`_. It's always a
-good idea to use the latest stable version available.
+`Elasticsearch site <http://www.elasticsearch.org/download/>`_ if you are unable to download it using the method that follows.
 
 First, make sure that `Java <https://www.java.com/en/>`__ is installed.
 Elasticsearch is compatible with both Java 6 and Java 7 and both can be found


### PR DESCRIPTION
Changed paragraph about Ubuntu not providing a package and that the most recent, stable version should be used. This is contrary to what the IMPORTANT note below it states, about AtoM only working with 0.90.11. I fell foul of this by jumping ahead and downloading/installing the latest version off the Elasticsearch web site, only to read further on that the newer version isn't supported. My wording could perhaps be improved, but you get the idea.
