### PR TITLE
Remove top line from example config, fix path

### DIFF
--- a/admin-manual/installation/asynchronous-jobs.rst
+++ b/admin-manual/installation/asynchronous-jobs.rst
@@ -63,8 +63,6 @@ could look like:
 
 .. code-block:: upstart
 
-   php symfony tools:gearman-worker
-
    description "AtoM worker (gearmand) upstart service"
    
    start on (started mysql)
@@ -74,7 +72,7 @@ could look like:
    respawn limit 5 10
    
    env LOCATION=/usr/share/nginx/atom
-   env LOGFILE=/usr/share/nginx/log/atom-worker.log
+   env LOGFILE=/usr/share/nginx/atom/log/atom-worker.log
    
    setuid www-data
    setgid www-data


### PR DESCRIPTION
It makes more sense that the log for the worker goes where the rest of the AtoM logs go, rather than its own directory.

Also, the top line in the example upstart config is not valid upstart config syntax and is unneeded.
