### PR TITLE
Correct info about Elasticsearch

### DIFF
--- a/admin-manual/installation/linux.rst
+++ b/admin-manual/installation/linux.rst
@@ -57,7 +57,7 @@ Elasticsearch
 
 A relatively new search server based on Apache Lucene and developed in Java that
 has brought AtoM a lot of advanced features, performance and scalability. This is
-probably the biggest change introduced in AtoM |version| and we are pleased
+probably the biggest change introduced in AtoM 2.x and we are pleased
 with the results.
 
 Ubuntu doesn't provide a package but you can download it directly from the


### PR DESCRIPTION
In the 2.1/2.2/2.3 docs the sentence "This is
probably the biggest change introduced in AtoM |version| " suggests that ES came with 2.1/2.2/2.3 when in reality it came with 2.0. Change to a fixed value of 2.x.
