### PR TITLE
Install php5-readline as part of the common apt part

### DIFF
--- a/admin-manual/installation/linux/ubuntu-trusty.rst
+++ b/admin-manual/installation/linux/ubuntu-trusty.rst
@@ -306,13 +306,7 @@ following command will install it along with the rest of PHP extensions
 
 .. code-block:: bash
 
-    sudo apt-get install php5-cli php5-fpm php5-curl php5-mysql php5-xsl php5-json php5-ldap php-apc
-
-If you are using Ubuntu 14.04, make sure that php5-readline is also installed.
-
-.. code-block:: bash
-
-    sudo apt-get install php5-readline
+    sudo apt-get install php5-cli php5-fpm php5-curl php5-mysql php5-xsl php5-json php5-ldap php5-readline php-apc
 
 If you are using Apache, you will also need to install mod_php:
 

--- a/admin-manual/installation/linux/ubuntu-xenial.rst
+++ b/admin-manual/installation/linux/ubuntu-xenial.rst
@@ -265,7 +265,7 @@ install it manually for now:
 
    sudo apt install php-dev
    sudo pecl install apcu_bc-beta
-   echo "extension=apc.so" | sudo tee > /etc/php/7.0/mods-available/apcu-bc.ini
+   echo "extension=apc.so" | sudo tee /etc/php/7.0/mods-available/apcu-bc.ini
    sudo ln -sf /etc/php/7.0/mods-available/apcu-bc.ini /etc/php/7.0/fpm/conf.d/30-apcu-bc.ini
    sudo ln -sf /etc/php/7.0/mods-available/apcu-bc.ini /etc/php/7.0/cli/conf.d/30-apcu-bc.ini
    sudo systemctl restart php7.0-fpm


### PR DESCRIPTION
Instead of having an extra step, install readline among other php5 packages.

This is a copy of #33 , that was deleted before being merged..