### PR TITLE
Add gears icon to settings page link in Browse

### DIFF
--- a/user-manual/access-content/browse.rst
+++ b/user-manual/access-content/browse.rst
@@ -142,7 +142,7 @@ descriptions, a pager will be provided at the bottom of the results.
 .. TIP::
 
    :term:`Administrators <administrator>` can change the default number of
-   results returned per page in **Admin > Settings > Global**. For more
+   results returned per page in |gears| **Admin > Settings > Global**. For more
    information, see: :ref:`results-page`.
 
 Results appear in the main column of the page - click on a result and AtoM will


### PR DESCRIPTION
Elsewhere in the documentation, whenever a link to the Admin menu is included, it is generally preceded by the gears icon, to help users better identify with the icon used in the AtoM user interface. I have added it to a missing spot in the Browse documentation.