### PR TITLE
Update links to ISAAR-CPF, fixes #51

### DIFF
--- a/user-manual/add-edit-content/authority-records.rst
+++ b/user-manual/add-edit-content/authority-records.rst
@@ -263,7 +263,7 @@ Add a new authority record from the main menu
 3. Enter data as required. The authority record edit template is based on the
    `ICA's <http://www.ica.org/>`__ *International Standard Archival Authority
    Record for Corporate Bodies, Persons and Families* 
-   (`ISAAR <https://www.ica.org/en/isaar-cpf-international-standard-archival-authority-record-corporate-bodies-persons-and-families-2nd>`__). 
+   (`ISAAR <https://www.ica.org/isaar-cpf-international-standard-archival-authority-record-corporate-bodies-persons-and-families-2nd>`__). 
    For more information on the use of particular fields in the ISAAR authority 
    record edit template, see: :ref:`ISAAR(CPF) <isaar-template>`.
 4. You can quit the creation process at any time by clicking the "Cancel"
@@ -497,7 +497,7 @@ page` of any other authority record via the "Add new" button in the
 3. Enter data as required. The authority record edit template is based on the
    `ICA's <http://www.ica.org/>`__ *International Standard Archival Authority
    Record for Corporate Bodies, Persons and Families* 
-   (`ISAAR <https://www.ica.org/en/isaar-cpf-international-standard-archival-authority-record-corporate-bodies-persons-and-families-2nd>`__). 
+   (`ISAAR <https://www.ica.org/isaar-cpf-international-standard-archival-authority-record-corporate-bodies-persons-and-families-2nd>`__). 
    For more information on the use of particular fields in the ISAAR authority 
    record edit template, see: :ref:`ISAAR(CPF) <isaar-template>`.
 4. You can quit the creation process at any time by clicking the "Cancel"

--- a/user-manual/add-edit-content/authority-records.rst
+++ b/user-manual/add-edit-content/authority-records.rst
@@ -262,12 +262,10 @@ Add a new authority record from the main menu
 
 3. Enter data as required. The authority record edit template is based on the
    `ICA's <http://www.ica.org/>`__ *International Standard Archival Authority
-   Record for Corporate Bodies, Persons and Families* (`ISAAR
-   <http://www.ica.org/10203/standards/isaar-cpf- international-standard-
-   archival-authority-record-for-corporate-bodies-persons- and-families-2nd-
-   edition.html>`__). For more information on the use of particular fields in
-   the ISAAR authority record edit template, see: :ref:`ISAAR(CPF)
-   <isaar-template>`.
+   Record for Corporate Bodies, Persons and Families* 
+   (`ISAAR <https://www.ica.org/en/isaar-cpf-international-standard-archival-authority-record-corporate-bodies-persons-and-families-2nd>`__). 
+   For more information on the use of particular fields in the ISAAR authority 
+   record edit template, see: :ref:`ISAAR(CPF) <isaar-template>`.
 4. You can quit the creation process at any time by clicking the "Cancel"
    button in the :term:`button block`; any data already entered will not be
    saved, and no new record will be created. Note that simply navigating away
@@ -498,12 +496,10 @@ page` of any other authority record via the "Add new" button in the
 
 3. Enter data as required. The authority record edit template is based on the
    `ICA's <http://www.ica.org/>`__ *International Standard Archival Authority
-   Record for Corporate Bodies, Persons and Families* (`ISAAR
-   <http://www.ica.org/10203/standards/isaar-cpf- international-standard-
-   archival-authority-record-for-corporate-bodies-persons- and-families-2nd-
-   edition.html>`__). For more information on the use of particular fields in
-   the ISAAR authority record edit template, see: :ref:`ISAAR(CPF)
-   <isaar-template>`.
+   Record for Corporate Bodies, Persons and Families* 
+   (`ISAAR <https://www.ica.org/en/isaar-cpf-international-standard-archival-authority-record-corporate-bodies-persons-and-families-2nd>`__). 
+   For more information on the use of particular fields in the ISAAR authority 
+   record edit template, see: :ref:`ISAAR(CPF) <isaar-template>`.
 4. You can quit the creation process at any time by clicking the "Cancel"
    button in the :term:`button block`; any data already entered will not be
    saved, and no new record will be created. Note that simply navigating away


### PR DESCRIPTION
I noticed that the links to the ICA's ISAAR-CPF standard are no longer working, because the ICA redesigned their website and did not add redirects. I have updated the links where they appear, in 2 places, with the current working URL.