### PR TITLE
Add permissive slug setting docs, fixes #82

### DIFF
--- a/admin-manual/maintenance/cli-tools.rst
+++ b/admin-manual/maintenance/cli-tools.rst
@@ -493,7 +493,10 @@ to manually insert a slug into the database for that entity.
 For information objects, the generate slugs task will respect the global
 settings for the source from which description permalinks are created. These
 settings can be controlled by an :term:`administrator` via the user interface
-- for more information, see: :ref:`description-permalinks`.
+- for more information, see: 
+
+* :ref:`description-permalinks`.
+* :ref:`permissive-slugs`
 
 Note that by default, existing slugs will **not** be replaced. If you want to
 generate new slugs for existing objects, you will need to first delete the
@@ -551,20 +554,53 @@ Users, Groups        Automatically generated
 Other entities       Name
 ==================== =============================
 
-Generated slugs will only allow digits, letters, and dashes. Sequences of
-unaccepted characters (e.g. accented or special characters, etc.) are replaced
-with valid characters such as English alphabet equivalents or dashes.
-This conforms to general practice around slug creation - for example,
-it is "common practice to make the slug all lowercase, accented characters are
-usually replaced by letters from the English alphabet, punctuation marks are
-generally removed, and long page titles should also be truncated to keep the
-final URL to a reasonable length"
-(`Wikipedia <http://en.wikipedia.org/wiki/Clean_URL#Slug>`__). In AtoM, slugs
-are truncated to a maximum of 250 characters.
+By default in new  installations, AtoM will "sanitize" slugs, removing spaces, 
+special characters, punctuation, and capital letters. However, this behavior can
+be changed by an administrator to allow a more permissive slug generation 
+pattern, where any UTF-8 character allowed by 
+`RFC 3987 <https://tools.ietf.org/html/rfc3987>`__ in an Internationalized 
+Resource Identifier 
+(`IRI <https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier>`__)
+can be used. For more information, see: 
+
+* :ref:`permissive-slugs`
+
+When this permissive mode is enabled, AtoM will allow the following to be used 
+in slugs: 
+
+* a-z, A-Z, and 0-9
+* All unicode characters specified in `RFC 3987 <https://tools.ietf.org/html/rfc3987>`__, 
+  including characters with accents
+* The following punctuation symbols: ``, - _ ~ : = * @``
+
+Certain special characters are still reserved either as specified by IRI
+requirements or based on how AtoM generates URLs. Consequently, even when
+permissive mode is enabled, some sanitization will still take place. For
+example:
+
+* Spaces will still be replaced by dashes
+* Special characters not listed above will be stripped - examples include: 
+  ``! ` " ' # $ / | \ + % ( ) { } [ ] . < > ?``
+
+When the permissive setting is set to "No" and slugs are being more 
+comprehensively sanitized, generated slugs will only allow digits, letters,
+and dashes. Sequences of unaccepted characters (e.g. accented or special
+characters, etc.) are replaced with valid characters such as English alphabet
+equivalents or dashes. This conforms to general practice around slug creation
+- for example, it is "common practice to make the slug all lowercase, accented
+characters are usually replaced by letters from the English alphabet,
+punctuation marks are generally removed, and long page titles should also be
+truncated to keep the final URL to a reasonable length"
+(`Wikipedia <http://en.wikipedia.org/wiki/Clean_URL#Slug>`__). 
+
+In AtoM, all slugs are truncated to a maximum of 250 characters. Case matters
+for the uniqueness of a slug - for example: ``my-slug`` is not considered the
+same as ``My-slug`` or ``My-Slug``, which could all point to different records
+in AtoM.
 
 If a slug is already in use, AtoM will append a dash and an incremental number
 (a numeric suffix) to the new slug - for example, if the slug "*correspondence*"
-is already in use, the next record with a title of "Correspondence" will
+is already in use, the next record with a title of "correspondence" will
 receive the slug "*correspondence-2*".
 
 If a record is created without data in the :term:`field` from which the slug
@@ -573,11 +609,12 @@ title), AtoM will assign it a randomly generated alpha-numeric slug. Once
 assigned, slugs for archival descriptions can be changed through the
 :term:`user interface`. Slugs for other entity types cannot be changed through
 the user interface - either the record must be deleted and a new record created,
-or you must manipulate the database directly.
+or you must manipulate the database directly, or use the :ref:`cli-generate-slugs` 
+task described above.
 
 .. TIP::
 
-   Users can also edit the slug associated with an :term:`archival description`
+   Users can edit the slug associated with an :term:`archival description`
    via the :term:`user interface`. For more information, see:
 
    * :ref:`rename-title-slug`

--- a/user-manual/add-edit-content/archival-descriptions.rst
+++ b/user-manual/add-edit-content/archival-descriptions.rst
@@ -1285,14 +1285,23 @@ using the "Rename" module.
 
 When editing a slug in AtoM, it is important to understand how they are
 generated, and why your slug may be saved differently than the value you
-input. Slugs in AtoM are sanitized to remove spaces, special characters (such
-as ! @ # $ % & etc), and capitalization. They are also truncated to a maximum
-of 250 characters. Since they are used as permalinks, they must also be unique
-within the system - so AtoM will automatically append a dash and an
-incrementing number to the end of non-unique slugs. More information on slugs
-in AtoM can be found here: :ref:`slugs-in-atom`. Whenever the Rename module
-alters the slug you enter based on the above parameters, a notification
-indicating this will be shown.
+input. By default, slugs in AtoM are sanitized to remove spaces, special
+characters (such as ! @ # $ % & etc), and capitalization. They are also
+truncated to a maximum of 250 characters. Since they are used as permalinks,
+they must also be unique within the system - so AtoM will automatically append
+a dash and an incrementing number to the end of non-unique slugs. More
+information on slugs in AtoM can be found here: :ref:`slugs-in-atom`. Whenever
+the Rename module alters the slug you enter based on the above parameters, a
+notification indicating this will be shown.
+
+.. TIP::
+
+   An :term:`administrator` can enable more permissive slug generation via 
+   |gears| **Admin > Settings > Global**. When enabled, capitalization, accents, 
+   and some special characters are preserved. For more information, see: 
+
+   * :ref:`permissive-slugs`
+   * :ref:`slugs-in-atom`
 
 Note that the title of a description can always be edited within the
 :term:`edit page` of the description itself - for more information, see above,

--- a/user-manual/administer/settings.rst
+++ b/user-manual/administer/settings.rst
@@ -89,6 +89,7 @@ This section will describe each setting in the "Global" :term:`information area`
 * :ref:`Upload multi-page files as multiple descriptions <upload-multi-files>`
 * :ref:`Show tooltips <tooltips>`
 * :ref:`Generate description permalinks from <description-permalinks>`
+* :ref:`permissive-slugs`
 * :ref:`Default publication status <default-publication-status>`
 * :ref:`drafts-notification`
 * :ref:`SWORD deposit directory <sword-directory>`
@@ -734,6 +735,34 @@ For further context on slugs in AtoM, see: :ref:`slugs-in-atom`
    interface, using the Rename module. For more information, see:
 
    * :ref:`rename-title-slug`
+
+.. _permissive-slugs:
+
+Use any valid URI path segment and uppercase character in slugs
+---------------------------------------------------------------
+
+This setting will affect how AtoM generates permalinks, or :term:`slugs <slug>` 
+for new records. In new installations, this setting is set to "No" by default. 
+
+When set to "No," generated slugs will only allow digits, letters, and dashes.
+Sequences of unaccepted characters (e.g. accented or special characters, etc.)
+are replaced with valid characters such as English alphabet equivalents or
+dashes. When set to to "Yes," AtoM will allow upper case characters, any valid
+unicode characters as specified in 
+`RFC 3987 <https://tools.ietf.org/html/rfc3987>`__ including accented characters, 
+and some special characters such as: ``, - _ ~ : = * @``. For further details, 
+see: 
+
+* :ref:`slugs-in-atom`
+
+The command-line task to generate slugs, and AtoM's Rename module (which will
+allow users to edit the slug associated with an :term:`archival description`) 
+will both respect and enforce the setting going forward. However, changing this
+setting will **not** automatically alter existing slugs. For more information, 
+see: 
+
+* :ref:`cli-generate-slugs`
+* :ref:`rename-title-slug`
 
 .. _default-publication-status:
 


### PR DESCRIPTION
This pull request will add a new entry into the Global section of the Settings documentation in the user manual. Updates have also been made to: 

* The generate slugs CLI task in the Admin manual, and its subsection on slugs in AtoM
* The Rename module instructions on the Archival description page in the User manual