### PR TITLE
Update version of less for installs, ref #13390

### DIFF
--- a/admin-manual/installation/linux/ubuntu-bionic.rst
+++ b/admin-manual/installation/linux/ubuntu-bionic.rst
@@ -519,9 +519,8 @@ After downloading the code, you will need to compile the CSS files:
 
 .. code-block:: bash
 
-   curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
    sudo apt install nodejs npm make
-   sudo npm install -g "less@<2.0.0"
+   sudo npm install -g "less@<4.0.0"
    sudo make -C /usr/share/nginx/atom/plugins/arDominionPlugin
 
 .. _linux-ubuntu-bionic-filesystem-permissions:


### PR DESCRIPTION
Change installation instructions to use standard Node.js in Ubuntu
Bionic and to install a newer version of less.