### PR TITLE
Document DO download API endpoint, refs #13436

### DIFF
--- a/dev-manual/api/api-intro.rst
+++ b/dev-manual/api/api-intro.rst
@@ -12,11 +12,12 @@ key associated with a user account can be passed with each request; details on
 each option and on generating an API key are included below in the
 :ref:`api-intro-auth` section.
 
-There are three endpoints available:
+There are several endpoints available:
 
 * :ref:`Browse taxonomy terms <api-browse-taxonomies>`
 * :ref:`Browse information objects <api-browse-io>`
 * :ref:`Read information object <api-read-io>`
+* :ref:`Download digital object <api-download-do>`
 
 .. _api-intro-plugin:
 

--- a/dev-manual/api/download-do.rst
+++ b/dev-manual/api/download-do.rst
@@ -1,0 +1,55 @@
+.. _api-download-do:
+
+================================
+Download digital object endpoint
+================================
+
+**GET /api/informationobjects/<slug>/digitalobject**
+
+This endpoint will stream the content of the master :term:`digital object`
+associated with the :term:`archival description` whose slug is provided.
+
+.. NOTE::
+
+   This endpoint supports streaming locally stored online
+   :term:`digital objects <digital object>`, as well as
+   external digital objects linked via a public URI. It is not possible to
+   stream offline digital objects with this endpoint.
+
+To be able to query the endpoint, you will need to know the :term:`slug` of
+the information object (aka :term:`archival description`) whose digital object
+you wish to download. Note that the slug is included in the
+:ref:`api-browse-io` response, so you could use it to determine the slug of a
+particular description if needed.
+
+.. _download-do-ex-req:
+
+Example request
+===============
+
+.. code-block:: none
+
+   curl -v -H "REST-API-Key: api-key" "https://www.example.com/api/informationobjects/test-description/digitalobject" --output sample_file.pdf
+
+.. _download-do-ex-resp:
+
+Example response
+================
+
+Example response is truncated and edited for readability.
+
+.. code-block:: none
+
+   HTTP/1.1 200 OK
+   Content-Type: application/pdf
+   Content-Length: 339503
+   Content-Description: File Transfer
+   Content-Transfer-Encoding: binary
+   Content-Disposition: attachment; filename=sample_file.pdf
+   Cache-Control: public, must-revalidate
+   Pragma: public
+
+   (file bitstream)
+
+
+:ref:`Back to top <api-download-do>`

--- a/dev-manual/index.rst
+++ b/dev-manual/index.rst
@@ -15,5 +15,6 @@ set of links to each chapter's main sections.
    api/browse-taxonomies
    api/browse-io
    api/read-io
+   api/download-do
 
 :ref:`Back to top <dev-manual-index>`


### PR DESCRIPTION
This commit adds documentation for the sponsored API endpoint added in https://github.com/artefactual/atom/commit/6fe216274c5ab140eef67fcbd6e26bf47de410e6.

The example request is a bit different here than in the other documented API endpoints (most notably, using curl in the example) because I wanted to show an example of handling the file bitstream sent in the response, but let me know if that's a problem.