### PR TITLE
Add homepage link to download DO API endpoint

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -280,3 +280,4 @@ sample requests and responses for available endpoints.
 * :ref:`api-browse-taxonomies`
 * :ref:`api-browse-io`
 * :ref:`api-read-io`
+* :ref:`api-download-do`


### PR DESCRIPTION
Hi @fiver-watson @peterVG - quick follow-up here to the last PR to add a link to the download digital object API endpoint page to the AtoM documentation homepage. Thanks!