### PR TITLE
Replace 'node.local: true' with 'transport.type: local'

### DIFF
--- a/admin-manual/maintenance/elasticsearch.rst
+++ b/admin-manual/maintenance/elasticsearch.rst
@@ -21,7 +21,7 @@ the following to /etc/elasticsearch/config/elasticsearch.yml
 
 .. code:: bash
 
-   node.local: true # disable network
+   transport.type: local # disable network
 
 Check the status of your Elasticsearch index
 ============================================


### PR DESCRIPTION
Using 'node.local: true' with elasticsearch 5 generates an 'unknown setting' error in elasticsearch.log
Per https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_settings_changes.html#_node_settings it has been replaced by 'transport.type: local'