### PR TITLE
Remove Bootstrap 5 img-fluid workaround

### DIFF
--- a/user-manual/add-edit-content/formatting.rst
+++ b/user-manual/add-edit-content/formatting.rst
@@ -398,16 +398,6 @@ An image of how these will render in AtoM:
    :alt: An example of markdown image formatting rendered in AtoM
 
 
-.. NOTE::
-
-   If you are using a Bootstrap 5 theme and have a wide image on a static page,
-   you might notice that it goes outside bounds.
-   Use the ``img-fluid`` class to fix this.
-
-   .. code-block:: bash
-
-      ![alt text](http://www.my-example-image.com/cat.png "title text"){.img-fluid}
-
 :ref:`Back to top <formatting>`
 
 .. _formatting-raw:

--- a/user-manual/administer/static-pages.rst
+++ b/user-manual/administer/static-pages.rst
@@ -779,18 +779,10 @@ you wanted an image of email, named "contact-image.jpg" included on your static
 
 .. code-block:: bash
 
-   ``<img src=".../path/to/contact-image.jpg">``
+   <img src=".../path/to/contact-image.jpg">
 
 ...where ``/path/to`` represents the internal URL path to the location of
 ``contact-image.jpg`` on your host server, or the path to a web-accessible image.
-
-.. NOTE::
-   If you are using a Bootstrap 5 theme and have a wide image, you might notice that it goes outside bounds.
-   Use the ``img-fluid`` class to fix this.
-
-   .. code-block:: bash
-
-      <img class="img-fluid" src="../path/to/contact-image.jpg">
 
 To center the image, you can wrap the ``<img>`` image element in a ``<div>``
 element, with a ``text-center"`` class, like this:


### PR DESCRIPTION
Remove the documentation for the img-fluid workaround for responsive static images since this would be fixed in the `2.7.3` release.