### PR TITLE
Updating gh actions version numbers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
       - name: "Set up Python"
-        uses: "actions/setup-python@v2"
+        uses: "actions/setup-python@v5"
       - name: "Install requirements"
         run: |
           pip install -r requirements.txt


### PR DESCRIPTION
While working on the spellchecking, I noticed this warning: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Here is a fix, if we want.