### PR TITLE
Fix typo: unnecessary s to publicationStatus - CSV column name

### DIFF
--- a/user-manual/data-templates/isad-template.rst
+++ b/user-manual/data-templates/isad-template.rst
@@ -1503,7 +1503,7 @@ Publication status
 
 **Template field** Publication status is available under the More tab located on the object view screen.
 
-**CSV column** ``publicationsStatus``
+**CSV column** ``publicationStatus``
 
 **RAD Rule** N/A
 


### PR DESCRIPTION
As mentioned in our emails.