### PR TITLE
Add instructions: offline docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sphinx-build -D language=en ./ _build/html/en # for English
 * Access the documentation:
 
 ```bash
-python3 -m http.server
+python3 -m http.server -d _build/html/
 ```
 
 The HTML files for the documentation will be in

--- a/README.md
+++ b/README.md
@@ -25,6 +25,62 @@ You are free to copy, modify, and distribute the AtoM documentation with
 attribution under the terms of the Creative Commons Attribution Share Alike 4.0
 (CC-BY-SA-4.0) license.  See the [LICENCE](LICENCE) file for details.
 
+## Building the documentation locally
+
+To build a local, offline version of the documentation:
+
+* Decide where the documentation will be stored on your computer.
+* In a Terminal window, use the `cd` command to navigate to this location.
+* Create a local copy of the documentation by running:
+
+```bash
+git clone https://github.com/artefactual/atom-docs.git
+```
+
+* Move to the documentation repository with:
+
+```bash
+cd atom-docs
+```
+
+* Create a Python virtual environment to contain all the required tools:
+
+```bash
+python3 -m venv .env
+```
+
+* Activate the virtual environment:
+
+```bash
+source .env/bin/activate
+```
+
+* Install the requirements:
+
+```bash
+pip install -r requirements.txt
+```
+
+* Build the documentation:
+
+```bash
+sphinx-build -D language=en ./ _build/html/en # for English
+```
+
+* Access the documentation:
+
+```bash
+python3 -m http.server
+```
+
+The HTML files for the documentation will be in
+`atom/_build/html/`.
+You can open the files in a browser of your choice, without having any access
+to the Internet.
+
+While this offline version will not have the AtoM web theme, you will
+gain access to improved search features.
+
 ## Contributing
 
 Thank you for considering a contribution to the AtoM documentation!  For more

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ python3 -m http.server -d _build/html/
 The HTML files for the documentation will be in
 `atom/_build/html/`.
 You can open the files in a browser of your choice, without having any access
-to the Internet.
+to the Internet, by accessing `http://localhost:8000`.
 
 While this offline version will not have the AtoM web theme, you will
 gain access to improved search features.


### PR DESCRIPTION
The goal is to allow for offline, local access of AtoM documentation.