### PR TITLE
Update sample nginx config web font formats (#290)

### DIFF
--- a/admin-manual/installation/ubuntu.rst
+++ b/admin-manual/installation/ubuntu.rst
@@ -714,7 +714,7 @@ contents in :file:`/etc/nginx/sites-available/atom`.
 
       client_max_body_size 72M;
 
-      location ~* ^/(css|dist|js|images|plugins|vendor)/.*\.(css|png|jpg|js|svg|ico|gif|pdf|woff|ttf)$ {
+      location ~* ^/(css|dist|js|images|plugins|vendor)/.*\.(css|png|jpg|js|svg|ico|gif|pdf|woff|woff2|otf|ttf)$ {
 
       }
 


### PR DESCRIPTION
Add woff2 and otf file extensions to the sample nginx config in the ubuntu installation section of the docs since these are common web font formats.