### PR TITLE
Add `add-po` to the dev manual menu

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -283,3 +283,4 @@ sample requests and responses for available endpoints.
 * :ref:`api-browse-io`
 * :ref:`api-read-io`
 * :ref:`api-download-do`
+* :ref:`api-add-po`


### PR DESCRIPTION
While reviewing the docs, I noticed this page was missing from the table of contents. I doubt it is on purpose ?

Let's add it!