### PR TITLE
Corrections to documentation for strong passwords feature

### DIFF
--- a/user-manual/administer/settings.rst
+++ b/user-manual/administer/settings.rst
@@ -2405,7 +2405,7 @@ Require strong passwords
 ------------------------
 
 This feature allows :term:`administrators <administrator>` to enhance login
-validation by requiring the use of strong passwords. Strong passwords use
+validation by requiring the use of strong passwords. Strong passwords use at
 least 8 characters, and contain characters from the following
 classes:
 

--- a/user-manual/administer/settings.rst
+++ b/user-manual/administer/settings.rst
@@ -2417,6 +2417,10 @@ classes:
 Choose "yes" to require authenticated (logged-in) users to have strong
 passwords.
 
+Note that this feature does not apply retroactively to existing users' passwords
+i.e. after enabling this option, users will not be asked to change their password
+if it is not already a strong password.
+
 :ref:`Back to top <settings>`
 
 .. _site-information:

--- a/user-manual/administer/settings.rst
+++ b/user-manual/administer/settings.rst
@@ -2406,7 +2406,7 @@ Require strong passwords
 
 This feature allows :term:`administrators <administrator>` to enhance login
 validation by requiring the use of strong passwords. Strong passwords use
-least 8 characters, and contain characters from 3 of the following
+least 8 characters, and contain characters from the following
 classes:
 
 #. Upper case letters


### PR DESCRIPTION
In addition to the corrections/addition proposed in this PR, the password strength indicator in the AtoM UI still appears to show the minimum password length that corresponds to strong passwords not enabled, even when strong passwords is enabled:

> * Make it at least six characters

I guess this is possibly one for artefactual/atom → Issues ?