### PR TITLE
Update references to latest AtoM version number from 2.8.0 to 2.8.2

### DIFF
--- a/admin-manual/installation/ubuntu.rst
+++ b/admin-manual/installation/ubuntu.rst
@@ -238,9 +238,9 @@ Option 1: Download the tarball
 
 .. code-block:: bash
 
-   wget https://storage.accesstomemory.org/releases/atom-2.8.0.tar.gz
+   wget https://storage.accesstomemory.org/releases/atom-2.8.2.tar.gz
    sudo mkdir /usr/share/nginx/atom
-   sudo tar xzf atom-2.8.0.tar.gz -C /usr/share/nginx/atom --strip 1
+   sudo tar xzf atom-2.8.2.tar.gz -C /usr/share/nginx/atom --strip 1
 
 Please note that the tarball may not be available yet if this version is still
 in development. In this case, you can try the alternative installation method


### PR DESCRIPTION
Note that there is still an outstanding reference to 2.8.0 that comes from line 232. However, the reference is indirect and uses the placeholder `|release|`.