### PR TITLE
Add instructions for ARM-based machines in Docker Compose setup

### DIFF
--- a/dev-manual/env/compose.rst
+++ b/dev-manual/env/compose.rst
@@ -72,6 +72,30 @@ don't want to do so each time we invoke the ``docker compose`` command.
    # For fish users
    set -lx COMPOSE_FILE (pwd)/docker/docker-compose.dev.yml
 
+ARM-based machines
+------------------
+
+If you are using an ARM-based machine such as Apple Silicon MacBooks, you will need to use
+an additional override file that is provided to ensure compatibility. The Elasticsearch and Percona
+images need to run with platform emulation since they don't support ARM64 natively.
+
+For ARM-based machines, set the ``COMPOSE_FILE`` environment variable to include
+both the development file and the ARM override file:
+
+.. code-block:: bash
+
+   # For bash users (most of you)
+   export COMPOSE_FILE="$PWD/docker/docker-compose.dev.yml:$PWD/docker/docker-compose.override.arm.yml"
+
+   # For fish users
+   set -lx COMPOSE_FILE (pwd)/docker/docker-compose.dev.yml:(pwd)/docker/docker-compose.override.arm.yml
+
+This override file forces Docker to use platform emulation to run the Elasticsearch and Percona containers 
+with ``linux/amd64`` architecture on ARM-based machines.
+
+Running the containers
+======================
+
 It's time to use Docker Compose in order to provision our containers:
 
 .. IMPORTANT::


### PR DESCRIPTION
Addresses one of the sub-issues in https://github.com/artefactual/atom-docs/issues/330