### PR TITLE
Add missing loggers: ~ to prod logging example, fixes #365

### DIFF
--- a/admin-manual/maintenance/logging.rst
+++ b/admin-manual/maintenance/logging.rst
@@ -211,6 +211,7 @@ high-level errors and warnings in a new ``qubit_prod.log`` file:
        param:
          level: warning
          file: %SF_LOG_DIR%/qubit_prod.log
+         loggers: ~
 
      storage:
        class: QubitSessionStorage


### PR DESCRIPTION
This was reproduced on 2.10 and caused error 500.